### PR TITLE
[WIP]buyer_idカラムの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@
 |shipping_period|integer|null: false|
 |user_id|integer|foreign_key: true|
 |category_id|integer|foreign_key: true|
+|buyer_id|integer||
+|sale_status|integer|null: false, default: 0|
+
 ### Association
 - has_many: pictures, dependent: :destroy
 - belongs_to: category

--- a/db/migrate/20200518171824_create_products.rb
+++ b/db/migrate/20200518171824_create_products.rb
@@ -12,7 +12,7 @@ class CreateProducts < ActiveRecord::Migration[5.2]
       t.references :user, index: true, foreign_key:true
       t.integer :category_id, foreign_key:true
       # t.integer :seller_id, null:false
-      # t.integer :buyer_id
+      t.integer :buyer_id
       t.integer :sale_status, null: false, default: 0
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2020_05_23_060627) do
     t.integer "shipping_period", null: false
     t.bigint "user_id"
     t.integer "category_id"
+    t.integer "buyer_id"
     t.integer "sale_status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
# WHAT
- マイグレーションファイルを編集し、buyer_idを追加
- READMEを編集

# WHY
- すでに購入された製品を区別できるようにするため
- 購入された製品がそのまま表示されることを防ぐため