### PR TITLE
商品出品機能の修正

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -22,19 +22,22 @@ class ProductsController < ApplicationController
   end
 
   def create
-    # binding.pry
-    @product = Product.new(product_params)
-      respond_to do |format|
-        if @product.save
-            params[:product_pictures][:picture].each do |picture|
-              @product.pictures.create(picture: picture, product_id: @product.id)
-            end
-          format.html{redirect_to root_path}
-        else
-          @product.pictures.build
-          format.html{render action: 'new'}
+    if params[:product_pictures].present?
+      @product = Product.new(product_params)
+        respond_to do |format|
+          if @product.save
+              params[:product_pictures][:picture].each do |picture|
+                @product.pictures.create(picture: picture, product_id: @product.id)
+              end
+            format.html{redirect_to root_path}
+          else
+            @product.pictures.build
+            format.html{render action: 'new'}
+          end
         end
-      end
+    else
+      redirect_to new_product_path
+    end
   end
   
   # destroy アクション nonaka


### PR DESCRIPTION
# What
画像がなくても出品できてしまうので、出品時の画像アップロードを必須にする機能を追加する。

# Why
出品した画像が無い場合、トップページの一覧表示が出来ず、エラーになってしまう為。

# 画像無しで出品できない動画（products/newに戻る）
https://gyazo.com/24d08a36d7bb74b707b5314ccd159d9d

# 成功の動画（トップページへ遷移）
https://gyazo.com/d590d9f3f9e60084a70e4e78b02fbc68