### PR TITLE
購入画面にカード情報と配送先を表示

### DIFF
--- a/app/assets/stylesheets/modules/_products_buy.scss
+++ b/app/assets/stylesheets/modules/_products_buy.scss
@@ -32,9 +32,13 @@
       width: 300px;
       display: flex;
       justify-content: space-between;
+      &__text{
+        display: flex;
+        justify-content: space-between;
+      }
       .registration{
         text-decoration: none;
-        color: rgb(50, 185, 238);
+        color: black;
         font-size: 12px;
         padding-top: 6px;
         position: relative;

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -62,7 +62,7 @@ class CardsController < ApplicationController
       Payjp.api_key = Rails.application.credentials.payjp[:secret_key]
       # 請求を発行
       Payjp::Charge.create(
-      amount: 1000,
+      amount: @products.price,
       customer: @card.customer_id,
       currency: 'jpy',
       )

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,8 +1,19 @@
 class ProductsController < ApplicationController
-  before_action :set_products,             only:[:show,:edit,:update]
+  before_action :set_products,            only:[:show,:edit,:update,:buy]
 
-  # require "payjp"
+  require "payjp"
   # before_action :set_card
+
+  def buy
+    @users = current_user
+    Payjp.api_key = Rails.application.credentials.payjp[:secret_key]
+    @card = current_user.card
+    customer = Payjp::Customer.retrieve(@card.customer_id) 
+    @card_info = customer.cards.retrieve(customer.default_card)
+    @exp_month = @card_info.exp_month.to_s
+    @exp_year = @card_info.exp_year.to_s.slice(2,3)
+  end
+
 
   def pay
     @product = Product.find(params[:product_id])
@@ -16,7 +27,7 @@ class ProductsController < ApplicationController
       Payjp.api_key = Rails.application.credentials.payjp[:secret_key]
       # 請求を発行
       Payjp::Charge.create(
-      amount: 1000,
+      amount: @products.price,
       customer: @card.customer_id,
       currency: 'jpy',
       )
@@ -110,10 +121,10 @@ class ProductsController < ApplicationController
     end
   end
 
-  def buy
-    @product = Product.find(params[:id])
-    #@address = Product.where(id: current_user.id)
-  end
+  # def buy
+  #   @product = Product.find(params[:id])
+  #   #@address = Product.where(id: current_user.id)
+  # end
 
   private
 

--- a/app/views/products/buy.html.haml
+++ b/app/views/products/buy.html.haml
@@ -23,23 +23,30 @@
           ="¥#{@product.price}"
       .border
       .buy-wrapper__main__title
+        支払い方法
         .buy-wrapper__main__title__text
-          支払い方法
-          - if @card.present?
-            .buy-wrapper__main__title__text.registration
-              = link_to cards_path, class:"registration" do
-                登録済みです
-          - else
+          - if @card.blank?
             .buy-wrapper__main__title__text.light.space
               = link_to new_cards_path, class:"Pay" do
                 登録してください
+          - else
+            .buy-wrapper__main__title__text.registration
+              .containerB
+                .creditcard-infoB
+                  %p.creditcard-info__numberB
+                    = "**** **** ****"  + @card_info.last4
+                  %p.creditcard-info__periodB
+                  = @exp_month + "/" + @exp_year
+            
       .border
       .buy-wrapper__main__title
+        配送先
         .buy-wrapper__main__title__text
-          配送先
           .buy-wrapper__main__title__text.light.width
-            = link_to root_path, class:"ShippingAddress" do
-              登録してください
+            = @users.zip_code
+            = @users.prefecture
+            = @users.city
+            = @users.street
       .border
       .buy-wapper__main__pay-btn
         = link_to "登録クレジットカードで購入する", controller: 'cards', action: 'pay', method: :post, class: "pay"


### PR DESCRIPTION
#what
・productsコントローラーにbuyアクションを定義し、payjpからカード情報・usersテーブルから住所の情報を取り出せるようにする。
・HTMLに情報を表示できるように記述。

#why
購入がスムーズに為されるための機能。